### PR TITLE
Fixing time to lowell and adding NH extension infill stations

### DIFF
--- a/src/stations.ts
+++ b/src/stations.ts
@@ -187,6 +187,12 @@ export const stationsByLine: Record<string, Station[]> = {
         { id: "place-NHRML-0152", name: "Wilmington" },
         { id: "place-NHRML-0218", name: "North Billerica" },
         { id: "place-NHRML-0254", name: "Lowell" },
+        { id: "place-rr-umass-lowell", name: "UMass Lowell" },
+        { id: "place-rr-rourke-bridge", name: "Rourke Bridge" },
+        { id: "place-rr-willow-springs", name: "Willow Springs" },
+        { id: "place-rr-nashua", name: "Nashua" },
+        { id: "place-rr-merrimack", name: "Merrimack" },
+        { id: "place-rr-manchester-center", name: "Manchester Center" },
     ],
     Haverhill: [
         { id: "place-WR-0329", name: "Haverhill" },

--- a/src/storydata/stationsByLine.ts
+++ b/src/storydata/stationsByLine.ts
@@ -186,6 +186,12 @@ export const stationsByLine = {
         { id: "place-NHRML-0152", name: "Wilmington" },
         { id: "place-NHRML-0218", name: "North Billerica" },
         { id: "place-NHRML-0254", name: "Lowell" },
+        { id: "place-rr-umass-lowell", name: "UMass Lowell" },
+        { id: "place-rr-rourke-bridge", name: "Rourke Bridge" },
+        { id: "place-rr-willow-springs", name: "Willow Springs" },
+        { id: "place-rr-nashua", name: "Nashua" },
+        { id: "place-rr-merrimack", name: "Merrimack" },
+        { id: "place-rr-manchester-center", name: "Manchester Center" },
     ],
     Haverhill: [
         { id: "place-WR-0329", name: "Haverhill" },


### PR DESCRIPTION
We were showing the old, slower times to North Billerica and Lowell. This PR fixes this and adds the additional NH extension stops as infill stations on the Lowell line. Screenshots included below.

Fixed travel time to Lowell
![image](https://user-images.githubusercontent.com/22358351/194442264-51109dec-ad12-4c0b-aa6f-08b5db04c4f5.png)

Lowell line / NH extension
![image](https://user-images.githubusercontent.com/22358351/194442381-4c169490-efe4-4ee5-8d13-21350a6cb304.png)

corresponding regional rail schedule generator PR: https://github.com/transitmatters/regional-rail-schedule-generator/pull/4
