### PR TITLE
Setting a start time when we cant get advantageous arrival time from …

### DIFF
--- a/src/components/Explorer/departures.ts
+++ b/src/components/Explorer/departures.ts
@@ -33,15 +33,33 @@ const getBestCandidateDepartureTime = (
 ) => {
     let bestCandidate: null | number = null;
     let bestDifference = Infinity;
-    candidates.forEach((candidate) => {
-        const nextEnhancedArrival = enhancedArrivals.find((t) => t >= candidate)!;
-        const difference = nextEnhancedArrival - candidate;
-        if (difference < bestDifference) {
-            bestDifference = difference;
-            bestCandidate = candidate;
+    if (candidates.length > 0) {
+        candidates.forEach((candidate) => {
+            const nextEnhancedArrival = enhancedArrivals.find((t) => t >= candidate)!;
+            const difference = nextEnhancedArrival - candidate;
+            if (difference < bestDifference) {
+                bestDifference = difference;
+                bestCandidate = candidate;
+            }
+        });
+        return bestCandidate;
+    }
+    // if we don't have candidates from the baseline, we need to pick a time based on enhancedArrivals
+    let firstArrival: null | number = null;
+    let secondArrival: null | number = null;
+    enhancedArrivals.forEach((arrival) => {
+        if (arrival > 32400 && !firstArrival) {
+            firstArrival = arrival;
+        } else if (arrival > 32400 && firstArrival && !secondArrival) {
+            secondArrival = arrival;
         }
     });
-    return bestCandidate;
+    if (firstArrival && secondArrival) {
+        // return midpoint between first 2 arrivals after 9am
+        return (firstArrival + secondArrival) / 2;
+    }
+    // if we still haven't found anything, default to 9am
+    return 32400;
 };
 
 export const getAdvantageousDepartureTime = (

--- a/src/components/Explorer/departures.ts
+++ b/src/components/Explorer/departures.ts
@@ -45,12 +45,13 @@ const getBestCandidateDepartureTime = (
         return bestCandidate;
     }
     // if we don't have candidates from the baseline, we need to pick a time based on enhancedArrivals
+    const targetArrival = 9 * 60 * 60; // 9 AM
     let firstArrival: null | number = null;
     let secondArrival: null | number = null;
     enhancedArrivals.forEach((arrival) => {
-        if (arrival > 32400 && !firstArrival) {
+        if (arrival >= targetArrival && !firstArrival) {
             firstArrival = arrival;
-        } else if (arrival > 32400 && firstArrival && !secondArrival) {
+        } else if (arrival > targetArrival && firstArrival && !secondArrival) {
             secondArrival = arrival;
         }
     });
@@ -59,7 +60,7 @@ const getBestCandidateDepartureTime = (
         return (firstArrival + secondArrival) / 2;
     }
     // if we still haven't found anything, default to 9am
-    return 32400;
+    return targetArrival;
 };
 
 export const getAdvantageousDepartureTime = (


### PR DESCRIPTION
…existing routes (in the case of infill stations)

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->
If you try to choose a route with an infill station, there is a bug when it can't find an appropriate arrival time using existing routes.

## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->
Get an arrival time for infills that is the midway point between the first 2 arrival times after 9am.

## Testing Instructions

<!-- How can the reviewer confirm these changes do what you say they do? -->
Test out routes involving infill stations.
