### PR TITLE
Drop EIP

### DIFF
--- a/devops/cloudformation.json
+++ b/devops/cloudformation.json
@@ -71,29 +71,6 @@
         ]
       }
     },
-    "RREEipAssociation": {
-      "Type": "AWS::EC2::EIPAssociation",
-      "Properties": {
-        "EIP": {
-          "Ref": "RREEip"
-        },
-        "InstanceId": {
-          "Ref": "RREInstance"
-        }
-      }
-    },
-    "RREEip": {
-      "Type": "AWS::EC2::EIP",
-      "Properties": {
-        "Domain": "vpc",
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "RRE-eip"
-          }
-        ]
-      }
-    },
     "RREDNSRecord": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
@@ -157,16 +134,18 @@
             "SslSupportMethod": "sni-only"
           }
         }
-      },
-      "DependsOn": [
-        "RREEipAssociation"
-      ]
+      }
     }
   },
   "Outputs": {
-    "InstanceIP": {
-      "Value": { "Ref": "RREEip" },
-      "Description": "RRE's public IP address"
+    "InstanceHostname": {
+      "Description": "RRE's public hostname",
+      "Value": {
+        "Fn::GetAtt": [
+          "RREInstance",
+          "PublicDnsName"
+        ]
+      }
     }
   }
 }

--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -37,11 +37,11 @@ aws cloudformation deploy --stack-name $STACK_NAME \
     RREDomain=$DOMAIN \
     RRECertArn=$CERT_ARN
 
-INSTANCE_IP=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='InstanceIP'].OutputValue" --output text)
+INSTANCE_HOSTNAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='InstanceHostname'].OutputValue" --output text)
 
 # Run the playbook! :-)
 export ANSIBLE_HOST_KEY_CHECKING=False # If it's a new host, ssh known_hosts not having the key fingerprint will cause an error. Silence it
-ansible-playbook -v -i $INSTANCE_IP, -u ubuntu --private-key ~/.ssh/transitmatters-rre.pem playbook.yml
+ansible-playbook -v -i $INSTANCE_HOSTNAME, -u ubuntu --private-key ~/.ssh/transitmatters-rre.pem playbook.yml
 
 # Grab the cloudfront ID and invalidate its cache
 CLOUDFRONT_ID=$(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items!=null] | [?contains(Aliases.Items, '$HOSTNAME')].Id | [0]" --output text)


### PR DESCRIPTION
We ended up not having to provide MBTA with an IP last year, so revert https://github.com/transitmatters/regional-rail-explorer/pull/64

Note that this does **not** eliminate costs from https://aws.amazon.com/blogs/aws/new-aws-public-ipv4-address-charge-public-ip-insights/