### PR TITLE
fix(wait-comparison): remove trailing 0 when wait is the same

### DIFF
--- a/src/components/JourneyComparison/WaitComparison.tsx
+++ b/src/components/JourneyComparison/WaitComparison.tsx
@@ -52,10 +52,12 @@ const WaitInfo = (props: WaitInfoProps) => {
         <>
             <div className="duration">
                 {stringifyDuration(waitDuration)} waiting for {serviceType} trains
-                {favorableWaitFraction && favorableWaitFraction! > 0 && (
+                {favorableWaitFraction && favorableWaitFraction! > 0 ? (
                     <div className="bubble offset-left green">
                         {Math.round(100 * favorableWaitFraction!)}% less
                     </div>
+                ) : (
+                    React.Fragment
                 )}
             </div>
         </>


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant issues -->
Fixes https://github.com/transitmatters/regional-rail-explorer/issues/102
## Changes

<!-- What does this change exactly? Include relevant screenshots, videos, links -->
Before
![image](https://github.com/transitmatters/regional-rail-explorer/assets/46619169/18e4a3cf-0c3f-4429-97c2-f951124eac8f)
After
![image](https://github.com/transitmatters/regional-rail-explorer/assets/46619169/973816de-829c-4b2d-b2ec-708a39ea5986)

## Testing Instructions

Navigate to some combination of stations such that the wait time is 0 and verify that the output looks correct. I used Medford Tufts and Warren Street at 8:40 AM on a weekday

<!-- How can the reviewer confirm these changes do what you say they do? -->
