### PR TITLE
Fix deprecated scss in styles

### DIFF
--- a/src/components/AmenityListing/AmenityListing.module.scss
+++ b/src/components/AmenityListing/AmenityListing.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $icon-wrapper-size: 2em;
 
@@ -6,7 +6,8 @@ $icon-wrapper-size: 2em;
     padding: 0;
     margin: 0;
     list-style-type: none;
-    & > *:not(:last-child) {
+
+    &>*:not(:last-child) {
         margin-bottom: 0.5em;
     }
 }
@@ -24,21 +25,23 @@ $icon-wrapper-size: 2em;
         justify-content: center;
         width: $icon-wrapper-size;
         height: $icon-wrapper-size;
-        border-radius: $icon-wrapper-size / 2;
+        border-radius: calc($icon-wrapper-size / 2);
         background: #bbb;
         box-sizing: border-box;
 
-        @include mobile {
+        @include base.mobile {
             align-self: flex-start;
         }
 
         &:global(.present) {
-            background: $rr-gold;
-            & > :global(.slash) {
+            background: base.$rr-gold;
+
+            &> :global(.slash) {
                 display: none;
             }
         }
-        & > :global(.slash) {
+
+        &> :global(.slash) {
             position: absolute;
             background: white;
             width: 2px;

--- a/src/components/AppFrame/AppFrame.module.scss
+++ b/src/components/AppFrame/AppFrame.module.scss
@@ -1,11 +1,11 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .appFrame {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
 
-    @include mobile {
+    @include base.mobile {
         font-size: 15px;
     }
 }
@@ -15,12 +15,12 @@
     align-items: center;
     height: 60px;
     padding: 0 10px;
-    background: $rr-purple-secondary;
+    background: base.$rr-purple-secondary;
     color: white;
     overflow: hidden;
     z-index: 2;
 
-    @include mobile {
+    @include base.mobile {
         flex-direction: column;
         align-items: flex-start;
         padding: 10px;

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .button {
     display: flex;
@@ -11,7 +11,7 @@
     margin: 0; // unset Safari
     cursor: pointer;
     background: whitesmoke;
-    box-shadow: $global-shadow;
+    box-shadow: base.$global-shadow;
     font-size: 0.9em;
     color: #111;
 
@@ -20,7 +20,8 @@
         color: whitesmoke;
         border: 2px solid rgba(white, 0.8);
         padding: 3px 8px;
-        svg > * {
+
+        svg>* {
             stroke: currentColor;
         }
     }
@@ -39,18 +40,18 @@
         padding: 8 16px;
     }
 
-    > .icon {
+    >.icon {
         display: flex;
         padding-right: 0.25em;
     }
 
-    > .rightIcon {
+    >.rightIcon {
         display: flex;
         margin-left: auto;
         padding-left: 0.25em;
     }
 
-    & > * {
+    &>* {
         min-height: 1em;
     }
 }

--- a/src/components/DeparturePicker/DeparturePicker.module.scss
+++ b/src/components/DeparturePicker/DeparturePicker.module.scss
@@ -1,13 +1,13 @@
-@import 'styles/base.scss';
+@use 'styles/base.scss';
 
-$top-color: $rr-gold;
-$bottom-color: $rr-purple-secondary;
+$top-color: base.$rr-gold;
+$bottom-color: base.$rr-purple-secondary;
 
 @mixin picker-triangle($color, $size: 8px) {
     position: absolute;
     z-index: 2;
     left: -$size;
-    @include triangle($color, $size);
+    @include base.triangle($color, $size);
 }
 
 .departurePicker {
@@ -17,6 +17,7 @@ $bottom-color: $rr-purple-secondary;
 
     &:not(.disabled):hover {
         cursor: pointer;
+
         .cursor {
             opacity: 1;
         }
@@ -40,7 +41,7 @@ $bottom-color: $rr-purple-secondary;
 .top {
     width: 100%;
     height: 8px;
-    box-shadow: $global-shadow;
+    box-shadow: base.$global-shadow;
     background: $top-color;
     box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
 }
@@ -51,9 +52,10 @@ $bottom-color: $rr-purple-secondary;
     margin-top: 20px;
     background: $bottom-color;
     box-shadow: 0px -1px 2px rgba(0, 0, 0, 0.1);
-    @include mobile {
+
+    @include base.mobile {
         background: $top-color;
-        box-shadow: $global-shadow;
+        box-shadow: base.$global-shadow;
     }
 }
 
@@ -75,6 +77,7 @@ $bottom-color: $rr-purple-secondary;
     position: absolute;
     color: #333;
     user-select: none;
+
     .cursorNeedle {
         position: absolute;
         bottom: 0;
@@ -83,6 +86,7 @@ $bottom-color: $rr-purple-secondary;
         left: -1px;
         background: currentColor;
     }
+
     .cursorTime {
         position: absolute;
         bottom: 0;
@@ -92,12 +96,10 @@ $bottom-color: $rr-purple-secondary;
         z-index: -1;
         font-size: 0.8em;
         white-space: nowrap;
-        background: linear-gradient(
-            90deg,
-            rgba(255, 255, 255, 1) 0%,
-            rgba(255, 255, 255, 1) 90%,
-            rgba(255, 255, 255, 0) 100%
-        );
+        background: linear-gradient(90deg,
+                rgba(255, 255, 255, 1) 0%,
+                rgba(255, 255, 255, 1) 90%,
+                rgba(255, 255, 255, 0) 100%);
     }
 }
 
@@ -131,7 +133,8 @@ $bottom-color: $rr-purple-secondary;
 .bottomTriangle {
     @include picker-triangle($bottom-color);
     bottom: 0;
-    @include mobile {
+
+    @include base.mobile {
         @include picker-triangle($top-color);
     }
 }

--- a/src/components/Explorer/Explorer.module.scss
+++ b/src/components/Explorer/Explorer.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .explorer {
     display: flex;
@@ -10,11 +10,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: $rr-purple;
+    color: base.$rr-purple;
 }
 
 .footer {
-    background: $darker-rr-purple;
+    background: base.$darker-rr-purple;
 }
 
 .footerInner {
@@ -32,7 +32,7 @@
         margin-bottom: 40px;
     }
 
-    @include mobile {
+    @include base.mobile {
         width: calc(100% - 40px);
     }
 }

--- a/src/components/FrequencyHistogram/FrequencyHistogram.module.scss
+++ b/src/components/FrequencyHistogram/FrequencyHistogram.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $arrival-width: 25px;
 
@@ -17,11 +17,12 @@ $arrival-width: 25px;
     align-items: center;
     flex-grow: 1;
     border-right: 1px solid #ddd;
+
     &:first-child {
         border-left: 1px solid #ddd;
     }
 
-    :global .time {
+    :global(.time) {
         user-select: none;
         position: absolute;
         bottom: -5px;
@@ -35,18 +36,18 @@ $arrival-width: 25px;
 @mixin arrival {
     width: $arrival-width;
     height: $arrival-width;
-    border-radius: #{$arrival-width / 2};
+    border-radius: calc($arrival-width / 2);
     margin-bottom: 5px;
     box-sizing: border-box;
 }
 
 .arrival {
     @include arrival;
-    background: $rr-purple;
-    border: #{$arrival-width / 4} solid $rr-light;
+    background: base.$rr-purple;
+    border: calc($arrival-width / 4) solid base.$rr-light;
 }
 
 .enhancedArrival {
     @include arrival;
-    background: $rr-purple;
+    background: base.$rr-purple;
 }

--- a/src/components/FrequencyTimeline/FrequencyTimeline.module.scss
+++ b/src/components/FrequencyTimeline/FrequencyTimeline.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $arrival-width: 8px;
 $mobile-arrival-width: 6px;
@@ -38,7 +38,7 @@ $mobile-arrival-width: 6px;
         white-space: nowrap;
         user-select: none;
 
-        @include mobile {
+        @include base.mobile {
             font-size: 10px;
         }
     }
@@ -62,18 +62,18 @@ $mobile-arrival-width: 6px;
     margin-bottom: 5px;
     box-sizing: border-box;
 
-    @include mobile {
+    @include base.mobile {
         width: $mobile-arrival-width;
         height: $mobile-arrival-width;
     }
 }
 
 .baselineArrival {
+    background: base.$rr-light;
     @include arrival;
-    background: $rr-light;
 }
 
 .enhancedArrival {
+    background: base.$rr-purple;
     @include arrival;
-    background: $rr-purple;
 }

--- a/src/components/GlobalNav/GlobalNav.module.scss
+++ b/src/components/GlobalNav/GlobalNav.module.scss
@@ -1,6 +1,7 @@
-@import '../../styles/base.scss';
+@use 'sass:list';
+@use '../../styles/base.scss';
 
-$logo-colors: $rr-purple, $rr-gold, white;
+$logo-colors: base.$rr-purple, base.$rr-gold, white;
 
 .globalNav {
     display: flex;
@@ -10,7 +11,7 @@ $logo-colors: $rr-purple, $rr-gold, white;
     height: 50px;
     box-sizing: border-box;
     overflow: hidden;
-    background: $darker-rr-purple;
+    background: base.$darker-rr-purple;
 }
 
 .logoContainer {
@@ -18,28 +19,33 @@ $logo-colors: $rr-purple, $rr-gold, white;
     align-items: center;
     margin-left: 15px;
     cursor: pointer;
-    > .text {
+
+    >.text {
         user-select: none;
         margin-left: 5px;
-        > .top {
+
+        >.top {
             font-size: 12px;
             font-weight: 500;
             letter-spacing: 0.1ch;
             text-align: center;
             white-space: nowrap;
         }
-        > .bottom {
+
+        >.bottom {
             font-size: 17px;
             text-transform: uppercase;
             font-weight: 300;
             font-style: italic;
         }
     }
-    @include mobile {
-        > .top {
+
+    @include base.mobile {
+        >.top {
             font-size: 11px;
         }
-        > .bottom {
+
+        >.bottom {
             font-size: 15px;
         }
     }
@@ -47,12 +53,14 @@ $logo-colors: $rr-purple, $rr-gold, white;
 
 .logo {
     height: 34px;
-    @for $i from 1 through length($logo-colors) {
+
+    @for $i from 1 through list.length($logo-colors) {
         path:nth-child(#{$i}) {
-            fill: nth($logo-colors, $i);
+            fill: list.nth($logo-colors, $i);
         }
     }
-    @include mobile {
+
+    @include base.mobile {
         height: 28px;
     }
 }
@@ -62,7 +70,8 @@ $logo-colors: $rr-purple, $rr-gold, white;
     align-items: center;
     margin-left: 15px;
     height: 100%;
-    @include mobile {
+
+    @include base.mobile {
         display: none;
     }
 }
@@ -76,14 +85,17 @@ $logo-colors: $rr-purple, $rr-gold, white;
     height: 100%;
     box-sizing: border-box;
     border-top: 4px solid transparent;
+
     &.active {
-        background: $rr-purple-secondary;
+        background: base.$rr-purple-secondary;
     }
+
     &:not(.active) {
         &:hover {
             background: rgba(white, 0.1);
         }
     }
+
     .linkIcon {
         margin-left: 3px;
     }

--- a/src/components/Home/Home.module.scss
+++ b/src/components/Home/Home.module.scss
@@ -1,11 +1,11 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .home {
     width: 100%;
-    background: $darker-rr-purple;
+    background: base.$darker-rr-purple;
     color: white;
 
-    @include mobile {
+    @include base.mobile {
         // scroll-snap-type: y proximity;
         // height: 100vh;
         // overflow-y: scroll;
@@ -25,7 +25,7 @@
     overflow: hidden;
     scroll-snap-align: start;
 
-    @include mobile {
+    @include base.mobile {
         padding: 20px;
     }
 
@@ -35,7 +35,7 @@
 }
 
 .network {
-    @include mobile {
+    @include base.mobile {
         margin: 20px 0;
     }
 }
@@ -67,7 +67,7 @@
     font-style: italic;
     text-align: center;
 
-    @include mobile {
+    @include base.mobile {
         font-size: 14px;
     }
 }
@@ -77,7 +77,7 @@
     z-index: 1;
     margin-bottom: 20px;
 
-    @include mobile {
+    @include base.mobile {
         margin-bottom: 0;
         height: 20px;
     }
@@ -103,12 +103,12 @@
     &:hover,
     &:active {
         background: white;
-        color: $darker-rr-purple;
+        color: base.$darker-rr-purple;
     }
 }
 
 .detailsScreen {
-    background: $darker-rr-purple;
+    background: base.$darker-rr-purple;
 
     hr {
         width: 100%;
@@ -126,7 +126,7 @@
     flex-direction: column;
     align-items: center;
 
-    @include mobile {
+    @include base.mobile {
         width: 100%;
         margin: 10px 0;
     }
@@ -137,7 +137,7 @@
     grid-template-columns: repeat(3, 1fr);
     column-gap: 60px;
 
-    @include mobile {
+    @include base.mobile {
         display: flex;
         flex-direction: column;
     }
@@ -152,7 +152,7 @@
         margin: 20px 0;
     }
 
-    @include mobile {
+    @include base.mobile {
         background-color: rgba(white, 0.1);
         padding: 16px;
         border-radius: 4px;
@@ -179,7 +179,7 @@
         line-height: 1.5em;
         text-align: center;
 
-        @include mobile {
+        @include base.mobile {
             font-size: 14px;
         }
     }

--- a/src/components/Home/OverviewCircle.module.scss
+++ b/src/components/Home/OverviewCircle.module.scss
@@ -1,10 +1,11 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 @mixin circle {
     width: 100px;
     height: 100px;
     border-radius: 50px;
-    @include mobile {
+
+    @include base.mobile {
         width: 50px;
         height: 50px;
     }
@@ -25,16 +26,18 @@
 }
 
 .center {
-    @include circle;
     background: white;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: $rr-purple;
+    color: base.$rr-purple;
+    @include circle;
+
     svg {
         width: 60px;
         height: 60px;
-        @include mobile {
+
+        @include base.mobile {
             width: 32px;
             height: 32px;
         }
@@ -42,19 +45,24 @@
 }
 
 .left {
-    @include circle;
+    background: base.$rr-gold;
+
     @include offset(-6px, true);
-    background: $rr-gold;
-    @include mobile {
+    @include circle;
+
+    @include base.mobile {
         @include offset(-4px, true);
     }
 }
 
 .right {
-    @include circle;
+    background: base.$rr-pink;
+
     @include offset(6px, true);
-    @include mobile {
+    @include circle;
+
+    @include base.mobile {
         @include offset(4px, true);
     }
-    background: $rr-pink;
+
 }

--- a/src/components/JourneyComparison/JourneyComparison.module.scss
+++ b/src/components/JourneyComparison/JourneyComparison.module.scss
@@ -1,27 +1,37 @@
-@import '../../styles/base.scss';
+@use 'sass:color';
+@use '../../styles/base.scss';
 
 .journeyComparison {
-    @include fill-to-max-width;
+    @include base.fill-to-max-width;
     margin-bottom: 30px;
+
+    @include base.mobile {
+        @include base.mobile-fill-to-max-width;
+    }
 
     :global(.bubble) {
         display: inline-block;
         color: white;
         padding: 3px 6px;
         margin-top: -3px;
+
         &:global(.green) {
             background: #579f6b;
         }
+
         &:global(.red) {
             background: #ec4747;
         }
+
         &:global(.offset-left) {
             margin-left: 6px;
-            @include mobile {
+
+            @include base.mobile {
                 margin-left: 0;
             }
         }
-        @include mobile {
+
+        @include base.mobile {
             display: block;
             margin: 0px;
             margin-top: 4px;
@@ -35,7 +45,8 @@
 
     :global(.duration) {
         font-size: 18px;
-        @include mobile {
+
+        @include base.mobile {
             font-size: 15px;
         }
     }
@@ -43,25 +54,29 @@
     :global(.column-header) {
         display: flex;
         align-items: center;
+
         :global(.header-blip) {
             margin-right: 8px;
             display: inline;
             height: 0.8em;
             width: 0.8em;
             border-radius: 100px;
+
             &:global(.baseline) {
-                background: $rr-light;
+                background: base.$rr-light;
             }
+
             &:global(.enhanced) {
-                background: $rr-purple;
+                background: base.$rr-purple;
             }
-            @include mobile {
+
+            @include base.mobile {
                 display: none;
             }
         }
     }
 
-    @include mobile {
+    @include base.mobile {
         margin-bottom: 0;
     }
 }
@@ -94,7 +109,8 @@
 
     &:first-child {
         margin-top: 20px;
-        @include mobile {
+
+        @include base.mobile {
             margin-top: 0;
         }
     }
@@ -103,7 +119,8 @@
         margin-bottom: 20px;
         padding-bottom: 20px;
         border-bottom: 1px #e5e5e5 solid;
-        @include mobile {
+
+        @include base.mobile {
             margin-bottom: 0;
             padding-bottom: 0;
         }
@@ -115,7 +132,7 @@
         border: none;
     }
 
-    @include mobile {
+    @include base.mobile {
         grid-template-columns: repeat(2, 1fr);
         grid-template-areas: 'baseline enhanced';
         column-gap: 0;
@@ -141,22 +158,23 @@
         }
 
         > :global(.baseline) {
-            border-color: $rr-light;
+            border-color: base.$rr-light;
             background: white;
         }
 
         > :global(.enhanced) {
-            border-color: $rr-purple;
-            background: lighten($rr-purple, 67%);
+            border-color: base.$rr-purple;
+            background: color.adjust(base.$rr-purple, $lightness: 67%);
         }
 
         &:global(.header) {
             > :global(.baseline) {
-                background: $rr-light;
+                background: base.$rr-light;
                 color: white;
             }
+
             > :global(.enhanced) {
-                background: $rr-purple;
+                background: base.$rr-purple;
                 color: white;
             }
         }
@@ -166,7 +184,7 @@
 .frequencyInfo {
     margin-right: 40px;
 
-    @include mobile {
+    @include base.mobile {
         margin-right: 0;
     }
 
@@ -174,19 +192,17 @@
         height: 1em;
         position: relative;
         margin-bottom: 20px;
+        mask-image: linear-gradient(90deg,
+                rgba(0, 0, 0, 0) 0%,
+                rgba(0, 0, 0, 1) 5%,
+                rgba(0, 0, 0, 1) 95%,
+                rgba(0, 0, 0, 0) 100%);
 
-        @include mobile {
+        @include base.mobile {
             padding: 2px 0;
             margin-bottom: 10px;
         }
 
-        mask-image: linear-gradient(
-            90deg,
-            rgba(0, 0, 0, 0) 0%,
-            rgba(0, 0, 0, 1) 5%,
-            rgba(0, 0, 0, 1) 95%,
-            rgba(0, 0, 0, 0) 100%
-        );
         :global(.line) {
             position: absolute;
             width: 100%;
@@ -195,6 +211,7 @@
             top: 50%;
             transform: translateY(-50%);
         }
+
         :global(.wait-line) {
             position: absolute;
             height: 2px;
@@ -204,6 +221,7 @@
             transform: translateY(-50%);
             box-sizing: border-box;
         }
+
         :global(.time) {
             position: absolute;
             transform: translateX(-50%) translateY(-50%);
@@ -211,12 +229,14 @@
             width: 8px;
             height: 8px;
             border-radius: 10px;
-            background: $rr-purple;
+            background: base.$rr-purple;
+
             &:global(.missed) {
-                box-shadow: 0 0 0 4px rgba($rr-purple, 0.5);
+                box-shadow: 0 0 0 4px rgba(base.$rr-purple, 0.5);
             }
+
             &:global(.caught) {
-                box-shadow: 0 0 0 4px rgba($rr-purple, 0.5);
+                box-shadow: 0 0 0 4px rgba(base.$rr-purple, 0.5);
             }
         }
     }

--- a/src/components/JourneyErrorState/JourneyErrorState.module.scss
+++ b/src/components/JourneyErrorState/JourneyErrorState.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .journeyErrorState {
     display: flex;
@@ -11,7 +11,7 @@
         margin: 0;
     }
 
-    @include mobile {
+    @include base.mobile {
         height: 200px;
     }
 }

--- a/src/components/JourneyPicker/JourneyPicker.module.scss
+++ b/src/components/JourneyPicker/JourneyPicker.module.scss
@@ -1,10 +1,10 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .journeyPicker {
     display: flex;
     align-items: center;
 
-    @include mobile {
+    @include base.mobile {
         flex-direction: column;
         align-items: flex-start;
         display: grid; // Fixes a Safari height: 100% issue with the swap stations button
@@ -20,9 +20,11 @@
         display: flex;
         align-items: center;
         margin-right: 10px;
-        @include mobile {
+
+        @include base.mobile {
             margin: 0;
             width: 100%;
+
             &:not(:last-child) {
                 margin-bottom: 10px;
             }
@@ -30,7 +32,7 @@
     }
 
     > :global(.group.from-to-stations) {
-        @include mobile {
+        @include base.mobile {
             display: grid;
             grid-template-areas:
                 'from swap'
@@ -41,6 +43,7 @@
 
             .labeledControl {
                 margin: 0;
+
                 > :first-child {
                     width: 35px;
                     text-transform: capitalize;
@@ -48,6 +51,7 @@
                     flex-shrink: 0;
                     margin-left: 0;
                 }
+
                 > :nth-child(2) {
                     flex-grow: 1;
                 }
@@ -55,7 +59,8 @@
 
             :global(.station-picker) {
                 width: 100%;
-                > button {
+
+                >button {
                     width: 100%;
                 }
             }
@@ -79,9 +84,10 @@
     }
 
     :global(.group.time-details) {
-        @include mobile {
+        @include base.mobile {
             overflow: scroll;
             justify-content: space-between;
+
             button {
                 flex-grow: 1;
             }
@@ -99,7 +105,8 @@
 
 .mobileSpacer {
     width: 0px;
-    @include mobile {
+
+    @include base.mobile {
         width: 10px;
     }
 }
@@ -111,7 +118,7 @@
 }
 
 .hiddenOnMobile {
-    @include mobile {
+    @include base.mobile {
         display: none;
     }
 }

--- a/src/components/JourneyTimeline/JourneyTimeline.module.scss
+++ b/src/components/JourneyTimeline/JourneyTimeline.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $stem-width: 8px;
 $text-offset: 25px;
@@ -8,8 +8,7 @@ $expand-control-size: 30px;
 $start-end-point-size: 16px;
 
 @mixin circle-on-line-with-label($circle-size) {
-    $circle-left: (
-        $travel-transfer-station-size - $circle-size) / 2;
+    $circle-left: calc(($travel-transfer-station-size - $circle-size) / 2);
     display: flex;
     align-items: center;
 
@@ -17,7 +16,7 @@ $start-end-point-size: 16px;
         margin-left: $circle-left;
         width: $circle-size;
         height: $circle-size;
-        border-radius: $circle-size / 2;
+        border-radius: calc($circle-size / 2);
         background-color: white;
         box-sizing: border-box;
         flex-shrink: 0;
@@ -33,11 +32,11 @@ $start-end-point-size: 16px;
 .journeyTimeline {
     position: relative;
 
-    @include mobile {
+    @include base.mobile {
         font-size: 13px;
     }
 
-    @include line-colors;
+    @include base.line-colors;
 }
 
 .travelSegment {
@@ -48,22 +47,21 @@ $start-end-point-size: 16px;
 
     :global(.stem) {
         position: absolute;
-        height: calc(100% - #{$travel-transfer-station-size}
-    );
-    top: $travel-transfer-station-size / 2;
-    left: $travel-transfer-station-size / 2;
-    transform: translateX(-50%);
-    width: $stem-width;
-    background: currentColor;
-}
+        height: calc(100% - #{$travel-transfer-station-size});
+        top: calc($travel-transfer-station-size / 2);
+        left: calc($travel-transfer-station-size / 2);
+        transform: translateX(-50%);
+        width: $stem-width;
+        background: currentColor;
+    }
 
-:global(.inner) {
-    padding: 10px 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    flex-grow: 1;
-}
+    :global(.inner) {
+        padding: 10px 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-around;
+        flex-grow: 1;
+    }
 }
 
 .travelSegmentPassedStation {
@@ -131,7 +129,7 @@ $start-end-point-size: 16px;
         font-weight: bold;
         line-height: 1em;
 
-        @include mobile {
+        @include base.mobile {
             flex-grow: 1;
         }
 
@@ -140,7 +138,7 @@ $start-end-point-size: 16px;
             margin-left: 0.5em;
             white-space: nowrap;
 
-            @include mobile {
+            @include base.mobile {
                 margin-left: auto;
             }
         }
@@ -189,7 +187,7 @@ $start-end-point-size: 16px;
         position: absolute;
         height: 100%;
         top: 0;
-        left: $travel-transfer-station-size / 2;
+        left: calc($travel-transfer-station-size / 2);
         transform: translateX(-50%);
         border: 1px dashed cornflowerblue;
     }

--- a/src/components/Menu/Menu.module.scss
+++ b/src/components/Menu/Menu.module.scss
@@ -1,11 +1,11 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .menu {
     list-style: none;
     padding: 0;
     margin: 0;
     background: white;
-    box-shadow: $global-shadow;
+    box-shadow: base.$global-shadow;
 }
 
 .menuItem {
@@ -15,10 +15,12 @@
     padding: 4px 10px;
     user-select: none;
     white-space: nowrap;
+
     &:hover,
     &[tabindex='0'] {
         background: #ddd;
-        svg > * {
+
+        svg>* {
             stroke: currentColor;
         }
     }

--- a/src/components/NumericTimePicker/NumericTimePicker.module.scss
+++ b/src/components/NumericTimePicker/NumericTimePicker.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 // Designed to be used in conjunction with the Button styles. Maybe that should be a mixin.
 .numericTimePicker {
@@ -8,7 +8,8 @@
     border-radius: 0;
     flex-grow: 1;
     height: 28.8px; // This is awful but I'm out of patience to fix this cross-browser
-    @include mobile {
+
+    @include base.mobile {
         height: 27px;
     }
 }

--- a/src/components/PowerText/PowerText.module.scss
+++ b/src/components/PowerText/PowerText.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 @mixin offset($position, $shadow: false) {
     position: absolute;
@@ -13,13 +13,15 @@
     color: white;
     position: relative;
     z-index: 0;
-    > * {
+
+    >* {
         margin: 0;
         font-weight: 600;
         font-style: italic;
         text-transform: uppercase;
         font-size: 48px;
-        @include mobile {
+
+        @include base.mobile {
             font-size: 24px;
         }
     }
@@ -27,11 +29,10 @@
 
 .middle {
     @include offset(-0.06em, true);
-    color: $rr-gold;
+    color: base.$rr-gold;
 }
 
 .bottom {
     @include offset(0.06em, true);
-    color: $rr-pink;
+    color: base.$rr-pink;
 }
-

--- a/src/components/RoutePage/RoutePage.module.scss
+++ b/src/components/RoutePage/RoutePage.module.scss
@@ -1,5 +1,5 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .routePage {
-    @include fill-to-max-width;
+    @include base.fill-to-max-width;
 }

--- a/src/components/RouteVisualizer/LiveRouteVisualizer.module.scss
+++ b/src/components/RouteVisualizer/LiveRouteVisualizer.module.scss
@@ -1,10 +1,11 @@
-@import '../../styles/base.scss';
+@use 'sass:color';
+@use '../../styles/base.scss';
 
 .container {
-    background: $rr-purple;
+    background: base.$rr-purple;
     padding: 10px;
     color: white;
-    box-shadow: $global-shadow;
+    box-shadow: base.$global-shadow;
 }
 
 .visualizerWrapper {
@@ -36,19 +37,20 @@
 
 .station {
     stroke: white;
-    fill: $rr-purple;
+    fill: base.$rr-purple;
     stroke-width: 2px;
 }
 
 .electricStroke {
-    stroke: lighten($rr-gold, 80%);
-    filter: drop-shadow(0px 0px 2px $rr-gold);
+    stroke: color.adjust(base.$rr-gold, $lightness: 80%);
+    filter: drop-shadow(0px 0px 2px base.$rr-gold);
 }
 
 .controls {
     display: flex;
     align-items: center;
-    > * {
+
+    >* {
         margin-right: 10px;
     }
 }

--- a/src/components/StationDetails/StationDetails.module.scss
+++ b/src/components/StationDetails/StationDetails.module.scss
@@ -1,4 +1,5 @@
-@import '../../styles/base.scss';
+@use 'sass:color';
+@use '../../styles/base.scss';
 
 .stationDetails {
     flex-grow: 1;
@@ -8,15 +9,20 @@
 }
 
 .inner {
-    @include fill-to-max-width;
+    @include base.fill-to-max-width;
+
     display: grid;
     overflow: hidden;
     grid-template-areas: 'info primary';
     grid-template-columns: 300px 1fr;
-    box-shadow: $global-shadow;
+    box-shadow: base.$global-shadow;
     margin-top: 20px;
     background: white;
     flex-grow: 1;
+
+    @include base.mobile {
+        @include base.mobile-fill-to-max-width;
+    }
 
     h1 {
         margin: 0;
@@ -37,15 +43,17 @@
 .map {
     width: 300px;
     height: 300px;
-    background: desaturate(lightgreen, 30%);
+    background: color.adjust(lightgreen, $saturation: -30%);
 }
 
 .metadata {
     padding: 0;
     margin: 0;
     list-style: none;
+
     li {
         padding: 8px;
+
         &:nth-child(even) {
             background: #ddd;
         }

--- a/src/components/StationListing/StationListing.module.scss
+++ b/src/components/StationListing/StationListing.module.scss
@@ -1,22 +1,24 @@
 @use 'sass:color';
-
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $inner-padding: 15px;
 $station-padding: 7px;
 
 @mixin color-line-group($color) {
-    > li {
+    >li {
         &:first-child {
             color: $color;
             font-weight: bold;
         }
     }
-    box-shadow: $global-shadow;
+
+    box-shadow: base.$global-shadow;
+
     &:global(.highlighted) {
-        > li {
+        >li {
             color: white;
         }
+
         background-color: $color;
     }
 }
@@ -29,17 +31,19 @@ $station-padding: 7px;
 }
 
 .header {
-    background: $rr-purple-secondary;
+    background: base.$rr-purple-secondary;
     padding: 10px $inner-padding;
 }
 
 .controls {
-    @include max-width;
+    @include base.max-width;
     display: flex;
     align-items: center;
-    @include mobile {
+
+    @include base.mobile {
         width: 100%;
         margin: 0;
+
         > :not(:last-child) {
             margin-right: 10px;
         }
@@ -55,7 +59,7 @@ $station-padding: 7px;
 }
 
 .stationList {
-    @include max-width;
+    @include base.max-width;
     column-width: 180px;
     padding: 0 $inner-padding;
     padding-bottom: $inner-padding;
@@ -64,20 +68,25 @@ $station-padding: 7px;
 
     li {
         display: flex;
+
         &:hover,
         &:focus {
             cursor: pointer;
             text-decoration: underline;
         }
+
         &[aria-disabled='true']:not(:first-child) {
             opacity: 0.5;
         }
+
         &:not(:last-child) {
             padding-bottom: $station-padding;
         }
+
         a {
             color: inherit;
             text-decoration: none;
+
             &:hover {
                 text-decoration: underline;
             }
@@ -102,27 +111,27 @@ $station-padding: 7px;
     border: 1px solid transparent;
 
     &:global(.red) {
-        @include color-line-group($red-line);
+        @include color-line-group(base.$red-line);
     }
 
     &:global(.orange) {
-        @include color-line-group($orange-line);
+        @include color-line-group(base.$orange-line);
     }
 
     &:global(.blue) {
-        @include color-line-group($blue-line);
+        @include color-line-group(base.$blue-line);
     }
 
     &:global(.green) {
-        @include color-line-group($green-line);
+        @include color-line-group(base.$green-line);
     }
 
     &:global(.silver) {
-        @include color-line-group($silver-line);
+        @include color-line-group(base.$silver-line);
     }
 
     &:global(.regional-rail) {
-        @include color-line-group($rr-purple);
+        @include color-line-group(base.$rr-purple);
     }
 
     &:global(.searching) {
@@ -134,7 +143,7 @@ $station-padding: 7px;
     display: flex;
     align-items: center;
 
-    > div {
+    >div {
         margin-left: 0.4em;
         width: 0.8em;
         height: 0.8em;
@@ -142,27 +151,27 @@ $station-padding: 7px;
         border-radius: 1em;
 
         &:global(.red) {
-            background-color: $red-line;
+            background-color: base.$red-line;
         }
 
         &:global(.orange) {
-            background-color: $orange-line;
+            background-color: base.$orange-line;
         }
 
         &:global(.blue) {
-            background-color: $blue-line;
+            background-color: base.$blue-line;
         }
 
         &:global(.green) {
-            background-color: $green-line;
+            background-color: base.$green-line;
         }
 
         &:global(.silver) {
-            background-color: $silver-line;
+            background-color: base.$silver-line;
         }
 
         &:global(.regional-rail) {
-            background-color: $rr-purple;
+            background-color: base.$rr-purple;
         }
     }
 }

--- a/src/components/StationListing/StationSearchBar.module.scss
+++ b/src/components/StationListing/StationSearchBar.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .search {
     width: 100%;
@@ -11,15 +11,18 @@
     background: rgba(white, 0.1);
     border: 2px solid transparent;
     color: white;
+
     &:focus {
         outline: none;
         border: 2px solid rgba(white, 0.8);
-        box-shadow: $global-shadow;
+        box-shadow: base.$global-shadow;
     }
+
     &::placeholder {
         color: rgba(white, 0.5);
     }
-    @include mobile {
+
+    @include base.mobile {
         font-size: 18px;
         height: 35px;
         margin: 0;

--- a/src/components/StationName/StationName.module.scss
+++ b/src/components/StationName/StationName.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .stationName {
     display: flex;
@@ -31,7 +31,7 @@
         top: 50%;
         width: max-content;
         padding: 2px 6px;
-        background-color: $rr-purple-secondary;
+        background-color: base.$rr-purple-secondary;
         color: #fff;
         font-style: italic;
     }
@@ -48,6 +48,7 @@
 a.nameText {
     color: inherit;
     text-decoration: none;
+
     &:hover {
         text-decoration: underline;
     }

--- a/src/components/StationPicker/StationPicker.module.scss
+++ b/src/components/StationPicker/StationPicker.module.scss
@@ -1,22 +1,24 @@
 @use 'sass:color';
-
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 $inner-padding: 15px;
 $station-padding: 7px;
 
 @mixin color-line-group($color) {
-    > li {
+    >li {
         &:first-child {
             color: $color;
             font-weight: bold;
         }
     }
-    box-shadow: $global-shadow;
+
+    box-shadow: base.$global-shadow;
+
     &:global(.highlighted) {
-        > li {
+        >li {
             color: white;
         }
+
         background-color: $color;
     }
 }
@@ -38,17 +40,17 @@ $station-padding: 7px;
 }
 
 .triangle {
-    @include triangle($rr-purple-secondary);
+    @include base.triangle(base.$rr-purple-secondary);
     transform: translateX(-50%);
 }
 
 .header {
-    background: $rr-purple-secondary;
+    background: base.$rr-purple-secondary;
     padding: 10px $inner-padding;
 }
 
 .controls {
-    @include max-width;
+    @include base.max-width;
 }
 
 .search {
@@ -62,11 +64,13 @@ $station-padding: 7px;
     background: rgba(white, 0.1);
     border: 2px solid transparent;
     color: white;
+
     &:focus {
         outline: none;
         border: 2px solid rgba(white, 0.8);
-        box-shadow: $global-shadow;
+        box-shadow: base.$global-shadow;
     }
+
     &::placeholder {
         color: rgba(white, 0.5);
     }
@@ -81,7 +85,7 @@ $station-padding: 7px;
 }
 
 .stationList {
-    @include max-width;
+    @include base.max-width;
     column-width: 180px;
     padding: 0 $inner-padding;
     padding-bottom: $inner-padding;
@@ -90,14 +94,17 @@ $station-padding: 7px;
 
     li {
         display: flex;
+
         &:hover,
         &:focus {
             cursor: pointer;
             text-decoration: underline;
         }
+
         &[aria-disabled='true']:not(:first-child) {
             opacity: 0.5;
         }
+
         &:not(:last-child) {
             padding-bottom: $station-padding;
         }
@@ -121,27 +128,27 @@ $station-padding: 7px;
     border: 1px solid transparent;
 
     &:global(.red) {
-        @include color-line-group($red-line);
+        @include color-line-group(base.$red-line);
     }
 
     &:global(.orange) {
-        @include color-line-group($orange-line);
+        @include color-line-group(base.$orange-line);
     }
 
     &:global(.blue) {
-        @include color-line-group($blue-line);
+        @include color-line-group(base.$blue-line);
     }
 
     &:global(.green) {
-        @include color-line-group($green-line);
+        @include color-line-group(base.$green-line);
     }
 
     &:global(.silver) {
-        @include color-line-group($silver-line);
+        @include color-line-group(base.$silver-line);
     }
 
     &:global(.regional-rail) {
-        @include color-line-group($rr-purple);
+        @include color-line-group(base.$rr-purple);
     }
 
     &:global(.searching) {
@@ -153,7 +160,7 @@ $station-padding: 7px;
     display: flex;
     align-items: center;
 
-    > div {
+    >div {
         margin-left: 0.4em;
         width: 0.8em;
         height: 0.8em;
@@ -161,27 +168,27 @@ $station-padding: 7px;
         border-radius: 1em;
 
         &:global(.red) {
-            background-color: $red-line;
+            background-color: base.$red-line;
         }
 
         &:global(.orange) {
-            background-color: $orange-line;
+            background-color: base.$orange-line;
         }
 
         &:global(.blue) {
-            background-color: $blue-line;
+            background-color: base.$blue-line;
         }
 
         &:global(.green) {
-            background-color: $green-line;
+            background-color: base.$green-line;
         }
 
         &:global(.silver) {
-            background-color: $silver-line;
+            background-color: base.$silver-line;
         }
 
         &:global(.regional-rail) {
-            background-color: $rr-purple;
+            background-color: base.$rr-purple;
         }
     }
 }

--- a/src/components/SuggestedJourneys/SuggestedJourneys.module.scss
+++ b/src/components/SuggestedJourneys/SuggestedJourneys.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/base.scss';
+@use '../../styles/base.scss';
 
 .journeys {
     display: grid;
@@ -7,7 +7,7 @@
     row-gap: 20px;
     width: 100%;
 
-    @include mobile {
+    @include base.mobile {
         display: flex;
         flex-direction: column;
     }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,9 +1,9 @@
 @use 'sass:color';
-@import './animations.scss';
+@use './animations.scss';
 
 $rr-purple: #742573;
 $rr-purple-secondary: #80276c;
-$darker-rr-purple: darken($rr-purple, 10%);
+$darker-rr-purple: color.adjust($rr-purple, $lightness: -10%);
 $rr-pink: #e424ba;
 $rr-gold: #e5b24b;
 $rr-light: color.mix($rr-purple, white, 30%);
@@ -79,16 +79,16 @@ $global-shadow: 0px 2px 2px rgba(black, 0.2);
     }
 }
 
+@mixin mobile-fill-to-max-width {
+    width: 100%;
+    max-width: 100vw;
+    overflow: hidden;
+}
+
 @mixin fill-to-max-width {
     width: 1200px;
     max-width: 95vw;
     margin: 0 auto;
-
-    @include mobile {
-        width: 100%;
-        max-width: 100vw;
-        overflow: hidden;
-    }
 }
 
 @mixin triangle($color, $size: 8px) {


### PR DESCRIPTION
## Motivation

Fixing warnings generated by dev server of deprecated scss syntax

## Changes

- Replace `@import` with `@use` and reference correct namespaces
- Fixing issues with ordering of nested and non-nested style 
- Using update functions for things like color.adjust(...)

## Testing Instructions



